### PR TITLE
chore: user_db.sql 외레키 유니크 삭제, user 쿼리 및 함수 수정

### DIFF
--- a/src/db/sql/user_db.sql
+++ b/src/db/sql/user_db.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS CharacterStats (
 
 CREATE TABLE IF NOT EXISTS Characters(
     id         INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    userId     INT NOT NULL UNIQUE,
+    userId     INT NOT NULL,
     charStatId INT NOT NULL,
     gold       INT DEFAULT 0,
     level      INT DEFAULT 1,
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS Characters(
 
 CREATE TABLE IF NOT EXISTS Market (
     id        INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    charId    INT NOT NULL UNIQUE,
+    charId    INT NOT NULL,
     itemIndex INT NOT NULL,
     upgrade   INT NOT NULL,
     price     INT NOT NULL,
@@ -48,7 +48,7 @@ CREATE TABLE IF NOT EXISTS Items (
 
 CREATE TABLE IF NOT EXISTS Inventory(
     id         INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    charId     INT NOT NULL UNIQUE,
+    charId     INT NOT NULL,
     itemId     INT NOT NULL,
     rarity     INT DEFAULT 0,
     equiped    BOOLEAN DEFAULT FALSE,

--- a/src/db/user/user.db.js
+++ b/src/db/user/user.db.js
@@ -21,8 +21,8 @@ export const updateUserLocation = async (x, y, id) => {
 };
 
 // 케릭터 생성. 
-export const createCharacter = async(userId, charStatId, gold, level, exp) => {
-  const [result] = await pools.USER_DB.query(SQL_QUERIES.CREATE_CHARACTER, [userId, charStatId, gold, level, exp]);
+export const createCharacter = async(userId, charStatId) => {
+  const [result] = await pools.USER_DB.query(SQL_QUERIES.CREATE_CHARACTER, [userId, charStatId]);
   
   // 해당 테이블의 id값을 반환 (성공여부 확인용)
   return result.insertId;
@@ -30,16 +30,16 @@ export const createCharacter = async(userId, charStatId, gold, level, exp) => {
 
 // 케릭터 업데이트. 
 export const updateCharacter = async (userId, charStatId, gold, level, exp) => {
-  const [result] = await pools.USER_DB.query(SQL_QUERIES.UPDATE_CHARACTER, [charStatId, gold, level, exp, userId]);
+  const [result] = await pools.USER_DB.query(SQL_QUERIES.UPDATE_CHARACTER, [gold, level, exp, userId, charStatId]);
 
   // 쿼리가 변경하거나 영향을 준 행의 개수를 검사 (업데이트 성공여부 확인용)
   return result.affectedRows > 0;
 }
 
 // userId로 케릭터 정보, 스텟을 가져오는 함수.
-export const findCharacterByUserId = async (id) => {
+export const findCharacterByUserAndStatId   = async (userId, charStatId) => {
   // 케릭터 정보, 스텟 을 담을 배열
-  const [characterInfo] = await pools.USER_DB.query(SQL_QUERIES.FIND_CHARACTER_BY_USER_ID, [id])
+  const [characterInfo] = await pools.USER_DB.query(SQL_QUERIES.FIND_CHARACTER_BY_USER_AND_STAT_ID, [userId, charStatId])
 
   // 만약에 읽어온 값이 0일 경우 null 반환.
   return characterInfo.length > 0 ? characterInfo[0] : null;

--- a/src/db/user/user.queries.js
+++ b/src/db/user/user.queries.js
@@ -4,12 +4,10 @@ export const SQL_QUERIES = {
   UPDATE_USER_LOGIN: 'UPDATE user SET last_login = CURRENT_TIMESTAMP WHERE device_id = ?',
   UPDATE_USER_LOCATION: 'UPDATE user SET x_coord = ?, y_coord = ? WHERE device_id = ?',
   // 쿼리문 추가 [케릭터 관련]
-  CREATE_CHARACTER:
-    'INSERT INTO Characters (userId, charStatId, gold, level, exp) VALUES (?, ?, ?, ?, ?)',
+  CREATE_CHARACTER: 'INSERT INTO Characters (userId, charStatId) VALUES (?, ?)',
   UPDATE_CHARACTER:
-    'UPDATE Characters SET charStatId = ?, gold = ?, level =?, exp =? WHERE userId = ?',
-  FIND_CHARACTER_BY_USER_ID:
-    'SELECT ch.*, cs.* FROM Characters ch JOIN CharacterStats cs ON ch.charStatId = cs.id WHERE ch.userId = ?',
+    'UPDATE Characters SET gold = ?, level = ?, exp = ? WHERE userId = ? AND charStatId = ?',
+  FIND_CHARACTER_BY_USER_AND_STAT_ID:
+    'SELECT ch.*, cs.* FROM Characters ch JOIN CharacterStats cs ON ch.charStatId = cs.id WHERE ch.userId = ? AND ch.id = ?',
   FIND_CHARACTER_STATS_BY_ID: 'SELECT * FROM CharacterStats WHERE id = ?',
 };
-

--- a/src/handlers/user/spawnUser.handler.js
+++ b/src/handlers/user/spawnUser.handler.js
@@ -179,7 +179,8 @@ export default spawnUserHandler;
 
 
 // 1. 원본 테이블 케릭터 디폴트 값 있습니다.
-// 2. 현재 한유저가 여러 플레이어 
+// 2. 현재 한유저가 여러 플레이어를 플래이했을경우 케릭터 검증. 
+// 3. 
 
   /*
  message S_Spawn {


### PR DESCRIPTION
- user_db.sql 외레키 UNIQUE 달려있는거 제거.
-  CREATE_CHARACTER 쿼리 수정.
- - [수정 전] 'INSERT INTO Characters (userId, charStatId, gold, level, exp) VALUES (?, ?, ?, ?, ?)',
- - [수정 후] 'INSERT INTO Characters (userId, charStatId) VALUES (?, ?)'
- UPDATE_CHARACTER 쿼리 수정.
- - [수정 전] 'UPDATE Characters SET charStatId = ?, gold = ?, level =?, exp =? WHERE userId = ?',
- - [수정 후] 'UPDATE Characters SET gold = ?, level = ?, exp = ? WHERE userId = ? AND charStatId = ?',
- FIND_CHARACTER_BY_USER_ID  쿼리 수정.
- -  [수정 전] 'SELECT ch.*, cs.* FROM Characters ch JOIN CharacterStats cs ON ch.charStatId = cs.id WHERE ch.userId = ?',
- -  [수정 후] 'SELECT ch.*, cs.* FROM Characters ch JOIN CharacterStats cs ON ch.charStatId = cs.id WHERE ch.userId = ? AND ch.id = ?',
- FIND_CHARACTER_BY_USER_ID  -> FIND_CHARACTER_BY_USER_AND_STAT_ID 이름 변경.
- createCharacter() 함수  쿼리문 변경으로 인해 수정. 
- updateCharacter()함수 쿼리문 변경으로 인해 수정.
- findCharacterByUserId()   -> findCharacterByUserAndStatId() 이름변경