### PR TITLE
fix : 매칭 완료시 버그 수정

### DIFF
--- a/src/classes/models/match.class.js
+++ b/src/classes/models/match.class.js
@@ -103,12 +103,21 @@ class Match {
             const party2LeaderLevel = party2.partyLeader.playerInfo.level;
             const party1Id = party1.id;
             const party2Id = party2.id;
+
             if (party1LeaderLevel >= party2LeaderLevel) {
               //해체되는 파티의 timoutId를 찾아서
-              const timeoutId = this.matchTimeouts[party2Id];
+              const timeout1Id = this.matchTimeouts[party1Id];
+              const timeout2Id = this.matchTimeouts[party2Id];
 
               //setTimeOut를 멈추고
-              clearTimeout(timeoutId);
+
+              if (timeout1Id) {
+                clearTimeout(timeout1Id);
+              }
+
+              if (timeout2Id) {
+                clearTimeout(timeout2Id);
+              }
 
               //timeOut기록들을 지운다
               delete this.matchTimeouts[party1Id];
@@ -123,10 +132,17 @@ class Match {
               return this.enterDungeon(party1);
             } else {
               //해체되는 파티의 timoutId를 찾아서
-              const timeoutId = this.matchTimeouts[party1Id];
+              const timeout1Id = this.matchTimeouts[party1Id];
+              const timeout2Id = this.matchTimeouts[party2Id];
 
               //setTimeOut를 멈추고
-              clearTimeout(timeoutId);
+              if (timeout1Id) {
+                clearTimeout(timeout1Id);
+              }
+
+              if (timeout2Id) {
+                clearTimeout(timeout2Id);
+              }
 
               //timeOut기록들을 지운다
               delete this.matchTimeouts[party1Id];


### PR DESCRIPTION
- 매칭 완료시에 cleartimeout에서 해체되는 파티가 상대라는 보장이 없기 떄문에 두개다 timeoutId를 가져와서 clearTImeout을 걸어줌