### PR TITLE
feat: 넉백 1차 병합

### DIFF
--- a/src/handlers/game/dungeon/dungeonSpawn.handler.js
+++ b/src/handlers/game/dungeon/dungeonSpawn.handler.js
@@ -1,5 +1,5 @@
 import { PACKET_TYPE } from '../../../constants/header.js';
-import { addUser, deleteUser, deleteMonsters, addMonster, deleteMovementSync, createMovementSync } from '../../../movementSync/movementSync.manager.js';
+import { addUser, deleteUser,  addMonster, deleteMovementSync, createMovementSync } from '../../../movementSync/movementSync.manager.js';
 import { getDungeonSession } from '../../../session/dungeon.session.js';
 import { getUserBySocket } from '../../../session/user.session.js';
 import { createResponse } from '../../../utils/response/createResponse.js';

--- a/src/movementSync/entity/classes/entity.class.js
+++ b/src/movementSync/entity/classes/entity.class.js
@@ -217,7 +217,7 @@ export default class Entity {
       this.updateLastTransform(this.currentTransform);
 
       if(this.behavior === CONSTANTS.AI_BEHAVIOR.DAMAGED ) {
-        console.error("피격중");
+        //console.error("피격중");
       }
     }
   }

--- a/src/movementSync/entity/classes/entity.class.js
+++ b/src/movementSync/entity/classes/entity.class.js
@@ -24,10 +24,23 @@ export default class Entity {
 
     this.isSearchFail = false;
 
+    this.attackCount = 0;
+    this.isAttack = false;
+    this.isDie = false;
+    this.isDamage = false;
+
+    // 데미지 
+    this.damageCount = 0;
+    this.power = 0; 
+    this.mass = 0; 
+    this.factor = 0; 
+    this.damageRot = 0; 
+    this.durationFactor = 0;
+
     console.log('생성 좌표 : ', this.currentTransform);
     console.log(` ID : ${this.id} / movementId : ${this.movementId}`);
 
-    // this.findAccessiblePosition();
+    this.findAccessiblePosition();
   }
 
   // [엔티티 스폰시 장애물 없는 곳에서 생성]
@@ -171,25 +184,28 @@ export default class Entity {
 
   // [트랜스폼 업데이트]
   updateTransform() {
-    //console.log(this.behavior);
-
     if (
-      this.behavior !== CONSTANTS.AI_BEHAVIOR.IDLE &&
-      this.behavior !== CONSTANTS.AI_BEHAVIOR.ATTACK
+      this.behavior !== CONSTANTS.AI_BEHAVIOR.IDLE 
     ) {
       // 방향 구하기.
       const { yaw } = movementUtils.Rotation(this.currentTransform, this.targetTransform);
 
       // 타겟 업데이트.
-      this.updateTargetTransform();
+      if(this.behavior !== CONSTANTS.AI_BEHAVIOR.ATTACK){
+        this.updateTargetTransform();
+      }
+      
 
       // 델타타임
       const deltaTime = 1 / CONSTANTS.NETWORK.TICK_RATE; // 프레임당 시간 (60FPS 기준)
 
       // 현재 좌표 업데이트.
-      this.currentTransform.posX += this.velocity.x * deltaTime;
-      this.currentTransform.posY += this.velocity.y * deltaTime;
-      this.currentTransform.posZ += this.velocity.z * deltaTime;
+      if(this.behavior !== CONSTANTS.AI_BEHAVIOR.ATTACK){
+        this.currentTransform.posX += this.velocity.x * deltaTime;
+        this.currentTransform.posY += this.velocity.y * deltaTime;
+        this.currentTransform.posZ += this.velocity.z * deltaTime;
+      }
+
       if (this.behavior !== CONSTANTS.AI_BEHAVIOR.DAMAGED) {
         this.currentTransform.rot = yaw;
       }
@@ -199,6 +215,10 @@ export default class Entity {
       //console.log(this.currentTransform);
       // 트랜스폼 스왑.
       this.updateLastTransform(this.currentTransform);
+
+      if(this.behavior === CONSTANTS.AI_BEHAVIOR.DAMAGED ) {
+        console.error("피격중");
+      }
     }
   }
 

--- a/src/movementSync/entity/classes/monster.class.js
+++ b/src/movementSync/entity/classes/monster.class.js
@@ -3,7 +3,7 @@ import CONSTANTS from '../../constants/constants.js';
 import movementUtils from '../../utils/movementUtils.js';
 import A_STER_MANAGER from '../../pathfinding/testASter.manager.js';
 import MONSTER_SEND_MESSAGE from '../../handlers/monster.handler.js';
-import { monsterApplyDamage } from '../../movementSync.manager.js';
+import { monsterApplyDamage, userApplyDamage } from '../../movementSync.manager.js';
 
 export default class Monster extends Entity {
   constructor(movementId, id, transform, model, name, hp) {
@@ -14,12 +14,6 @@ export default class Monster extends Entity {
     this.hp = hp;
 
     this.spawnTransform = { ...this.currentTransform };
-    this.attackCount = 0;
-    this.isAttack = false;
-    this.isDie = false;
-    this.isDamage = false;
-
-    
   }
 
   // 0.
@@ -34,27 +28,27 @@ export default class Monster extends Entity {
   getIsDie() {
     return this.isDie;
   }
-  setIsDie(isDie){
+  setIsDie(isDie) {
     this.isDie = isDie;
   }
 
   getIsDamage() {
     return this.isDamage;
   }
-  setIsDamage(isDamage){
-    this.isDie = isDamage;
+  setIsDamage(isDamage) {
+    this.isDamage = isDamage;
   }
 
   getHp() {
     return this.hp;
   }
 
-  setHp(hp){
-    this.hp = hp
+  setHp(hp) {
+    this.hp = hp;
   }
 
   updateTransform(userTransform) {
-    if(this.isDie) return;
+    if (this.isDie) return;
 
     this.updateMonsterSync(userTransform);
     super.updateTransform();
@@ -63,6 +57,10 @@ export default class Monster extends Entity {
   // 1. updateMonsterSync
   updateMonsterSync(userTransform) {
     const behavior = super.getBehavior();
+
+    if (this.isDamage) {
+      this.monsterAiBehaviorDAMAGED(userTransform);
+    }
 
     if (behavior === CONSTANTS.AI_BEHAVIOR.IDLE) {
       this.isAttack = false;
@@ -82,13 +80,11 @@ export default class Monster extends Entity {
           this.monsterAiBehaviorATTACK(userTransform);
           break;
         case CONSTANTS.AI_BEHAVIOR.DAMAGED:
+          console.log('여긴와?');
           this.monsterAiBehaviorDAMAGED(userTransform);
           break;
         default:
           break;
-      }
-      if (behavior === CONSTANTS.AI_BEHAVIOR.CHASE) {
-        //this.monsterAiBehaviorCHASE();
       }
     }
   }
@@ -102,16 +98,14 @@ export default class Monster extends Entity {
     const distance01 = movementUtils.Distance(this.currentTransform, userTransform); // 거리 계산
 
     //console.log('유저 <-> 몬스터 거리: ', distance01);
-    if (distance01 <= 2) {
+    if (movementUtils.obbCollision(4, 4, this.currentTransform, userTransform)) {
       super.setBehavior(CONSTANTS.AI_BEHAVIOR.ATTACK);
       A_STER_MANAGER.UPDATE_OBSTACLE(this.movementId, this);
       this.attackCount = 60;
     }
-    
 
     // 거리가 1보다 클경우
-    if (distance01 >= 2) {
-      
+    if (distance01 >= 1) {
       // 길찾기 도착지점 갱신.
       super.setPathfindingDestination(userTransform);
       super.updatePathFinding(this.currentTransform, this.pathfindingDestination);
@@ -124,9 +118,17 @@ export default class Monster extends Entity {
     const currentTransform = super.getCurrentTransform();
     const targetTransform = super.getTargetTransform();
 
+    const distance01 = movementUtils.Distance(this.currentTransform, userTransform); // 거리 계산
+
+    if (movementUtils.obbCollision(4, 4, this.currentTransform, userTransform)) {
+      super.setBehavior(CONSTANTS.AI_BEHAVIOR.ATTACK);
+      A_STER_MANAGER.UPDATE_OBSTACLE(this.movementId, this);
+
+      this.attackCount = 60;
+    }
+
     const aSterPath = super.getASterPath();
 
-  
     if (aSterPath.size() === 0) {
       const result = movementUtils.hasPassedTarget(
         currentTransform,
@@ -136,21 +138,24 @@ export default class Monster extends Entity {
 
       if (result) {
         // 1. 이곳은 패스 (경로)에 도착할때마다 실행 하는 로직.
-        
+
         // 2. 스폰 위치와 이동 목표가 가깝다면 복귀하는중이다.
-        const spawnDistance = movementUtils.Distance(this.pathfindingDestination, this.spawnTransform);
-        
-        if(spawnDistance <= 0.5){
+        const spawnDistance = movementUtils.Distance(
+          this.pathfindingDestination,
+          this.spawnTransform,
+        );
+
+        if (spawnDistance <= 0.5) {
+          monsterApplyDamage(this.movementId, this.id, 5);
           super.setBehavior(CONSTANTS.AI_BEHAVIOR.IDLE);
         }
 
-        // 3. 복귀 중이 아니고 목표에 도달했으면 
-        if(spawnDistance > 0.5){
+        // 3. 복귀 중이 아니고 목표에 도달했으면
+        if (spawnDistance > 0.5) {
           super.setBehavior(CONSTANTS.AI_BEHAVIOR.IDLE);
           //super.setBehavior(CONSTANTS.AI_BEHAVIOR.ATTACK);
         }
 
-        
         return false;
       } else {
         super.setBehavior(CONSTANTS.AI_BEHAVIOR.CHASE);
@@ -176,155 +181,97 @@ export default class Monster extends Entity {
     const currentTransform = super.getCurrentTransform();
 
     // 공격 수정
-    if(this.attackCount === 0) {
-      const distance = movementUtils.Distance(this.currentTransform, userTransform);
-      if(distance <= 1){
-        super.setBehavior(CONSTANTS.AI_BEHAVIOR.ATTACK);
-        this.isAttack = false;
-        this.attackCount = 60;
-      } else {
-        super.setBehavior(CONSTANTS.AI_BEHAVIOR.RETURN);
-        //super.setBehavior(CONSTANTS.AI_BEHAVIOR.ATTACK);
-        this.isAttack = false;
-        //this.attackCount = 60;
-      }
-      
+    if (this.attackCount === 0) {
+      super.setBehavior(CONSTANTS.AI_BEHAVIOR.RETURN);
+      this.isAttack = false;
     }
 
     if (this.attackCount === 60) {
-      // 몬스터의 공격 범위 설정 (2D 사각형)
-      const attackRange = 4;
-      const halfRange = attackRange / 2;
-
-      const minX = this.currentTransform.posX - halfRange;
-      const maxX = this.currentTransform.posX + halfRange;
-      const minZ = this.currentTransform.posZ - halfRange;
-      const maxZ = this.currentTransform.posZ + halfRange;
+      // 몬스터 -> 유저 바라보는 rot 계싼
+      const { yaw } = movementUtils.Rotation(this.currentTransform, userTransform);
+      console.log('1. rot : ', this.currentTransform.rot);
+      this.currentTransform.rot = yaw;
+      console.log('2. rot : ', this.currentTransform.rot);
 
       // 유저가 공격 범위 내에 있는지 확인
-      if (
-        userTransform.posX >= minX &&
-        userTransform.posX <= maxX &&
-        userTransform.posZ >= minZ &&
-        userTransform.posZ <= maxZ
-      ) {
+      if (movementUtils.obbCollision(4, 4, this.currentTransform, userTransform)) {
         this.isAttack = true;
         if (this.isAttack) {
-          //console.log('공격 성공!');
-          MONSTER_SEND_MESSAGE.ATTCK('town');
-          super.setBehavior(CONSTANTS.AI_BEHAVIOR.RETURN);
+          MONSTER_SEND_MESSAGE.ATTCK(this.movementId);
           this.isAttack = false;
-        }
-      } else {
-        super.setBehavior(CONSTANTS.AI_BEHAVIOR.IDLE);
-        this.isAttack = false;
+          console.log('[공격이 들어오는 시점]');
 
-        console.log(`몬스터 공격 범위 X : minX ${minX} / maxX ${maxX}`);
-        console.log(`몬스터 공격 범위 Y : minZ ${minZ} / maxZ ${maxZ}`);
-        console.log(`플레이어 위치    X : X    ${userTransform.posX} / Z    ${userTransform.posZ}`);
-      }
+          userApplyDamage(this.movementId, '1', this.id);
+        }
+      } 
     }
 
     this.attackCount--;
   }
 
-  monsterAiBehaviorDAMAGED(users) {
-    const currentTransform = super.getCurrentTransform();
+  monsterAiBehaviorDAMAGED(userTransform) {
+    if (this.damageCount > 0) {
+      // Knockback 계산 (넉백 파워 = (공격력 / 무게) * 밀리는 강도)
+      const knockbackPower = (this.power / this.mass) * this.factor;
+      const velocity = movementUtils.DirectionAndVelocity(
+        userTransform,
+        this.currentTransform,
+        knockbackPower,
+      );
+      this.velocity = { ...velocity };
 
-    let closestUser = null; // 가장 가까운 유저.
-    let minDistance = Infinity; // 가장 작은 거리로 초기화
+      // 방향 계산 (몬스터가 피격된 방향으로 회전)
+      const { yaw } = movementUtils.Rotation(this.currentTransform, userTransform);
+      this.damageRot = yaw;
+      this.currentTransform.rot = this.damageRot;
 
-    users.forEach((user) => {
-      const userTransform = user.getTransform(); // 유저의 트랜스폼 정보
+      // 넉백 방향이 장애물인 경우 바로 피격 종료.
+      //const deltaTime = 1 / CONSTANTS.NETWORK.TICK_RATE;
+      const pos = {
+        posX: this.currentTransform.posX + velocity.x + 1,
+        posY: this.currentTransform.posY + velocity.y + 1,
+        posZ: this.currentTransform.posZ + velocity.z + 1,
+      };
 
-      const distance = movementUtils.Distance(currentTransform, userTransform); // 거리 계산
-      if (distance < minDistance) {
-        minDistance = distance;
-        closestUser = user;
+      if (A_STER_MANAGER.FIND_OBSTACLE_POSITION(this.movementId, pos)) {
+        console.log('못가는곳에 왔어요');
+        this.resetDamageState();
+        return;
       }
-    });
 
-    if (closestUser) {
-      const userTransform = closestUser.getTransform();
-
-      const distance = movementUtils.Distance(this.currentTransform, userTransform);
-
-      if (distance >= 2 && distance <= 3) {
-        const velocity = movementUtils.DirectionAndVelocity(
-          userTransform,
-          this.currentTransform,
-          CONSTANTS.ENTITY.DEFAULT_SPEED,
-        );
-
-        // 유저 -> 몬스터 방향으로 이동  5 좌표 만큼.
-        const offset = 2;
-        const targetPos = {
-          posX: this.currentTransform.posX + velocity.x * offset, // 현재 위치에서 반대 방향으로 이동
-          posY: this.currentTransform.posY + velocity.y * offset,
-          posZ: this.currentTransform.posZ + velocity.z * offset,
-          rot: movementUtils.Rotation(currentTransform, userTransform),
-        };
-
-        // 스타트 엔드 포스.
-
-        // 패스 갱신.
-        // 길찾기 도착지점 갱신.
-        super.setPathfindingDestination(targetPos);
-
-        // 시작
-        const startPos = [
-          this.currentTransform.posX,
-          this.currentTransform.posY,
-          this.currentTransform.posZ,
-        ];
-
-        // 도착
-        const endPos = [
-          this.pathfindingDestination.posX,
-          this.pathfindingDestination.posY,
-          this.pathfindingDestination.posZ,
-        ];
-
-        // 패스 갱신.
-        A_STER_MANAGER.DELETE_OBSTACLE(this.movementId, this.id);
-        const paths = A_STER_MANAGER.FIND_PATH(this.movementId, startPos, endPos);
-
-        if (paths.length === 0) {
-          return;
-        }
-
-        for (const path of paths) {
-          this.aSterPath.enqueue(path);
-        }
-
-        if (this.aSterPath.size() !== 0) {
-          this.aSterPath.delete();
-        }
-
-        for (const path of paths) {
-          this.aSterPath.enqueue(path);
-        }
-
-        let path = this.aSterPath.dequeue();
-        if (path !== null) {
-          this.currentTransform.posX = path[0];
-          this.currentTransform.posY = path[1];
-          this.currentTransform.posZ = path[2];
-        }
-
-        path = this.aSterPath.dequeue();
-        if (path !== null) {
-          this.targetTransform.posX = path[0];
-          this.targetTransform.posY = path[1];
-          this.targetTransform.posZ = path[2];
-        }
-
-        // 초기 방향 설정.
-        super.updateVelocity();
-
-        // 행동 변경.
-        //super.setBehavior(CONSTANTS.AI_BEHAVIOR.CHASE);
-      }
+      // 점진적으로 감속 (실제 시간 기준 감소)
+      // 0.1 * (1 / mass) = 기본 감속 속도 (무게가 클수록 감속이 느림)
+      this.damageCount -= 0.1 * (1 / this.mass);
+    } else {
+      this.resetDamageState();
     }
+  }
+
+  // 피격 상태 초기화 함수
+  resetDamageState() {
+    super.setBehavior(CONSTANTS.AI_BEHAVIOR.IDLE);
+    this.damageCount = CONSTANTS.ENTITY.DEFAULT_SPEED;
+    this.isDamage = false;
+    A_STER_MANAGER.UPDATE_OBSTACLE(this.movementId, this);
+  }
+
+  // 넉백 지속시간 계산 (프레임 단위 변환)
+  //  (공격력 / 무게) = 기본 넉백 영향도 (공격력이 높을수록 넉백 증가, 무게가 높을수록 감소)
+  // 밀리는 강도와 지속시간을 반영하여 넉백 지속시간 계산
+  updateDamageCount(power, mass, factor, durationFactor) {
+    A_STER_MANAGER.DELETE_OBSTACLE(this.movementId, this.id);
+
+    this.aSterPath.delete();
+
+    this.isDamage = true;
+    super.setBehavior(CONSTANTS.AI_BEHAVIOR.DAMAGED);
+
+    this.power = power; // 파워
+    this.mass = mass; // 무개
+    this.factor = factor; // 밀리는 강도
+    this.durationFactor = durationFactor; // 밀리는 시간.
+
+    // 넉백 지속시간 계산
+    this.damageCount = (this.power / this.mass) * this.factor * durationFactor;
   }
 }

--- a/src/movementSync/entity/classes/monster.class.js
+++ b/src/movementSync/entity/classes/monster.class.js
@@ -189,9 +189,9 @@ export default class Monster extends Entity {
     if (this.attackCount === 60) {
       // 몬스터 -> 유저 바라보는 rot 계싼
       const { yaw } = movementUtils.Rotation(this.currentTransform, userTransform);
-      console.log('1. rot : ', this.currentTransform.rot);
+      //console.log('1. rot : ', this.currentTransform.rot);
       this.currentTransform.rot = yaw;
-      console.log('2. rot : ', this.currentTransform.rot);
+      //console.log('2. rot : ', this.currentTransform.rot);
 
       // 유저가 공격 범위 내에 있는지 확인
       if (movementUtils.obbCollision(4, 4, this.currentTransform, userTransform)) {
@@ -199,7 +199,7 @@ export default class Monster extends Entity {
         if (this.isAttack) {
           MONSTER_SEND_MESSAGE.ATTCK(this.movementId);
           this.isAttack = false;
-          console.log('[공격이 들어오는 시점]');
+          console.log('[몬스터 공격 성공하는 시점]');
 
           userApplyDamage(this.movementId, '1', this.id);
         }
@@ -234,7 +234,7 @@ export default class Monster extends Entity {
       };
 
       if (A_STER_MANAGER.FIND_OBSTACLE_POSITION(this.movementId, pos)) {
-        console.log('못가는곳에 왔어요');
+        //console.log('못가는곳에 왔어요');
         this.resetDamageState();
         return;
       }

--- a/src/movementSync/entity/classes/user.class.js
+++ b/src/movementSync/entity/classes/user.class.js
@@ -162,9 +162,9 @@ export default class User extends Entity {
 
       for(const pos of testArr){
         if (A_STER_MANAGER.FIND_OBSTACLE_POSITION(this.movementId, pos)) {
-          console.error("유저 넉백 장애물 불가");
+          // console.error("유저 넉백 장애물 불가");
           this.resetDamageState();
-          console.error("[넉백 불가]");
+          console.error("[유저 - 넉백 불가]");
           return;
         }
       }
@@ -175,7 +175,7 @@ export default class User extends Entity {
       
 
     } else {
-      console.error("유저피격 끝");
+      // console.error("유저피격 끝");
       this.resetDamageState();
     }
   }

--- a/src/movementSync/entity/classes/user.class.js
+++ b/src/movementSync/entity/classes/user.class.js
@@ -9,6 +9,13 @@ export default class User extends Entity {
 
     this.socket = socket;
     this.latency = 0;
+
+    this.damageTagetMonster = {
+      posX : 0,
+      posY : 0,
+      posZ : 0,
+      rot : 0,
+    }
   }
 
   // [유저 트랜스폼 동기화]
@@ -25,10 +32,11 @@ export default class User extends Entity {
 
   // [트랜스폼 업데이트]
   updateTransform() {
+    if (this.behavior === CONSTANTS.AI_BEHAVIOR.DAMAGED) {
+      this.userAiBehaviorDAMAGED(this.damageTagetMonster);
+    }
+    
     super.updateTransform();
-
-    // 여기 고치자..
-    //console.log(this.aSterPath.size());
 
     if (this.behavior === CONSTANTS.AI_BEHAVIOR.CHASE) {
       this.userAiBehaviorCHASE();
@@ -99,5 +107,105 @@ export default class User extends Entity {
     return ping * 2;
   }
 
-  // [랜덤 좌표]
+  // [유저 피격]
+  userAiBehaviorDAMAGED( monsterTransform) {
+    if (this.damageCount > 0) {
+      // Knockback 계산 (넉백 파워 = (공격력 / 무게) * 밀리는 강도)
+      const knockbackPower = (this.power / this.mass) * this.factor;
+
+      const velocity = movementUtils.DirectionAndVelocity(
+        monsterTransform,
+        this.currentTransform,
+        knockbackPower,
+      );
+      this.velocity = { ...velocity };
+
+      // 방향 계산 (몬스터가 피격된 방향으로 회전)
+      const { yaw } = movementUtils.Rotation(this.currentTransform, monsterTransform);
+      this.damageRot = yaw;
+      this.currentTransform.rot = this.damageRot;
+
+
+      // 넉백 각도 
+      const knockback = movementUtils.Rotation(monsterTransform, this.currentTransform);
+      const { topLeft, topRight, bottomLeft, bottomRight } = movementUtils.obbBox(1,1,this.currentTransform, knockback.yaw);
+
+
+
+      // 넉백 방향이 장애물인 경우 바로 피격 종료.
+      // 지금은 테스트라 y축은 냅두는데 테스트 종료후 삭제예정
+      // 테스트
+      const testArr = [];
+      testArr.push({
+        posX: topLeft.x,
+        posY: 0,
+        posZ: topLeft.z,
+      })
+
+      testArr.push({
+        posX: topRight.x,
+        posY: 0,
+        posZ: topRight.z,
+      })
+
+      testArr.push({
+        posX: bottomLeft.x,
+        posY: 0,
+        posZ: bottomLeft.z,
+      })
+
+      testArr.push({
+        posX: bottomRight.x,
+        posY: 0,
+        posZ: bottomRight.z,
+      })
+
+      for(const pos of testArr){
+        if (A_STER_MANAGER.FIND_OBSTACLE_POSITION(this.movementId, pos)) {
+          console.error("유저 넉백 장애물 불가");
+          this.resetDamageState();
+          console.error("[넉백 불가]");
+          return;
+        }
+      }
+
+      // 점진적으로 감속 (실제 시간 기준 감소)
+      // 0.1 * (1 / mass) = 기본 감속 속도 (무게가 클수록 감속이 느림)
+      this.damageCount -= 0.1 * (1 / this.mass);
+      
+
+    } else {
+      console.error("유저피격 끝");
+      this.resetDamageState();
+    }
+  }
+
+  // 피격 상태 초기화 함수
+  resetDamageState() {
+    super.setBehavior(CONSTANTS.AI_BEHAVIOR.IDLE);
+    this.damageCount = CONSTANTS.ENTITY.DEFAULT_SPEED;
+    this.isDamage = false;
+    A_STER_MANAGER.UPDATE_OBSTACLE(this.movementId, this);
+  }
+
+  // 넉백 지속시간 계산 (프레임 단위 변환)
+  //  (공격력 / 무게) = 기본 넉백 영향도 (공격력이 높을수록 넉백 증가, 무게가 높을수록 감소)
+  // 밀리는 강도와 지속시간을 반영하여 넉백 지속시간 계산
+  updateDamageCount(power, mass, factor, durationFactor, monsterTransform) {
+    A_STER_MANAGER.DELETE_OBSTACLE(this.movementId, this.id);
+    
+    this.aSterPath.delete();
+    this.damageTagetMonster = {...monsterTransform};
+    
+    this.isDamage = true;
+    super.setBehavior(CONSTANTS.AI_BEHAVIOR.DAMAGED);
+
+    this.power = power; // 파워
+    this.mass = mass; // 무개
+    this.factor = factor; // 밀리는 강도
+    this.durationFactor = durationFactor; // 밀리는 시간.
+
+    // 넉백 지속시간 계산
+    this.damageCount = (this.power / this.mass) * this.factor * durationFactor;
+  }
 }

--- a/src/movementSync/entity/manager/entity.manager.js
+++ b/src/movementSync/entity/manager/entity.manager.js
@@ -45,28 +45,28 @@ export default class EntityManager {
   addMonster(movementId) {
     // movementId -> town일때만
     // movementId -> dungeon1이면 다른 생성 지점을 가져야 할듯
-    // let transform = {};
+    let transform = {};
     console.log('Add Monster : ', movementId);
-    // if(movementId === 'town') {
-    //   transform = {
-    //     posX: this.generateRandomPlayerTransformInfo(-9, 9),
-    //     posY: 1,
-    //     posZ: this.generateRandomPlayerTransformInfo(-8, 8) + 130,
-    //     rot: this.generateRandomPlayerTransformInfo(0, 360),
-    //   };
-    // } else {
-    const transform = {
+    if(movementId === 'town') {
+      transform = {
+        posX: this.generateRandomPlayerTransformInfo(-9, 9),
+        posY: 1,
+        posZ: this.generateRandomPlayerTransformInfo(-8, 8) + 130,
+        rot: this.generateRandomPlayerTransformInfo(0, 360),
+      };
+    } else {
+    transform = {
       posX: 2,
       posY: 1,
       posZ: 25,
       rot: this.generateRandomPlayerTransformInfo(0, 360),
     };
-    //}
+    }
 
     const monsterId = uuidv4();
     const randomNum = Math.floor(Math.random() * 30) + 1;
 
-    this.monsters[monsterId] = new Monster(movementId, monsterId, transform, 3, 'test', 10);
+    this.monsters[monsterId] = new Monster(movementId, monsterId, transform, randomNum, 'test', 10);
   }
 
   deleteMonster(id) {

--- a/src/movementSync/movementSync.class.js
+++ b/src/movementSync/movementSync.class.js
@@ -97,12 +97,11 @@ export default class MovementSync {
       const userTransformInfo = [];
       for (const user of users) {
         if (user.getBehavior() !== CONSTANTS.AI_BEHAVIOR.IDLE) {
-          if (user.userAiBehaviorCHASE()) {
-            // user.updateTransform();
-            if (user.getIsSearchFail()) continue;
-            const syncData = this.createSyncTransformInfoData(user);
-            userTransformInfo.push(syncData);
-          }
+          console.error("[유저가 메세지를 보내고있습니다.]")
+          console.warn("pos : ", user.getTransform());
+          if (user.getIsSearchFail()) continue;
+          const syncData = this.createSyncTransformInfoData(user);
+          userTransformInfo.push(syncData);
         }
       }
 
@@ -200,7 +199,7 @@ export default class MovementSync {
       .map((monster) => monster.getId()); // 몬스터 ID만 추출
 
     if (monsterIds.length !== 0) {
-      const sMonsterDie = {
+      const sMonsterDamage = {
         monsterId: monsterIds,
         monsterAinID: 'Hit',
       };
@@ -209,10 +208,12 @@ export default class MovementSync {
         'town',
         'S_MonsterHit',
         PACKET_TYPE.S_MonsterHit,
-        sMonsterDie,
+        sMonsterDamage,
       );
 
       this.broadcast2(initialResponse);
+
+      console.log('왔어요.');
     }
   }
 
@@ -280,7 +281,7 @@ export default class MovementSync {
       }
 
       // 몬스터수 제한
-      if (monsters.length >= 10) {
+      if (monsters.length >= 5) {
         return;
       }
 
@@ -317,9 +318,10 @@ export default class MovementSync {
 
   startMovementProcess() {
     this.processMovement();
-    if (this.movementId !== 'town') {
-      this.processMonsterSpawn();
-    } 
+    // if (this.movementId !== 'town') {
+    //   this.processMonsterSpawn();
+    // }
+    this.processMonsterSpawn();
     this.entityMovement();
   }
 

--- a/src/movementSync/movementSync.class.js
+++ b/src/movementSync/movementSync.class.js
@@ -97,8 +97,8 @@ export default class MovementSync {
       const userTransformInfo = [];
       for (const user of users) {
         if (user.getBehavior() !== CONSTANTS.AI_BEHAVIOR.IDLE) {
-          console.error("[유저가 메세지를 보내고있습니다.]")
-          console.warn("pos : ", user.getTransform());
+          //console.error("[유저가 메세지를 보내고있습니다.]")
+          //console.warn("pos : ", user.getTransform());
           if (user.getIsSearchFail()) continue;
           const syncData = this.createSyncTransformInfoData(user);
           userTransformInfo.push(syncData);
@@ -156,9 +156,6 @@ export default class MovementSync {
         await this.broadcast2(initialResponse2);
       }
 
-      // 공격/ 죽음
-      //this.updateMonsterAttck();
-      //this.updateMonsterDie();
     }, CONSTANTS.NETWORK.INTERVAL);
   }
 
@@ -320,6 +317,8 @@ export default class MovementSync {
     if (this.movementId !== 'town') {
       this.processMonsterSpawn();
     }
+
+    //this.processMonsterSpawn();
     this.entityMovement();
   }
 

--- a/src/movementSync/movementSync.manager.js
+++ b/src/movementSync/movementSync.manager.js
@@ -173,7 +173,7 @@ export const userApplyDamage = (movementSyncId, userId, monsterId) =>{
     return false;
   }
 
-  console.log("[유저가 넉백하는 시점]")
+  // console.log("[유저가 넉백하는 시점]")
 
   // 유저, 몬스터 정보를 불러온다.
   const monster = findMonster(movementSyncId, monsterId);

--- a/src/movementSync/movementSync.manager.js
+++ b/src/movementSync/movementSync.manager.js
@@ -1,6 +1,7 @@
 import MovementSync from './movementSync.class.js';
 import { createResponse } from '../utils/response/createResponse.js';
 import { PACKET_TYPE } from '../constants/header.js';
+import CONSTANTS from './constants/constants.js';
 const movementSyncs = {};
 
 // [movementSync 생성].
@@ -129,7 +130,7 @@ export const deleteMonster = (movementSyncId, id) => {
   return movementSyncs[movementSyncId].deleteMonster(id);
 };
 
-// [몬스터 피격 ]
+// [몬스터 피격]
 export const monsterApplyDamage = (movementSyncId, id, damage) => {
   if (!findMovementSync(movementSyncId)) {
     console.log(`movementSync 가 존재 하지 않습니다 (id : ${movementSyncId})`);
@@ -147,6 +148,7 @@ export const monsterApplyDamage = (movementSyncId, id, damage) => {
     console.log("몬스터 체력 :",monsterHp);
     monster.setHp(monsterHp);
 
+    console.log('몬스터체력 :',  monsterHp);
     // 2-2. 몬스터 체력 조건문. 
     if(monsterHp <= 0) {  
       // 3. 몬스터 사망처리
@@ -157,6 +159,8 @@ export const monsterApplyDamage = (movementSyncId, id, damage) => {
 
     } else {
       // 5. 몬스터 피격 클라이언트에 브로드 캐스트.
+      // 무게, 파워, 밀리는강도, 지속시간)
+      monster.updateDamageCount(1, 10, 20, 0.1);
       movementSyncs[movementSyncId].updateMonsterDamage();
     }
 
@@ -164,3 +168,21 @@ export const monsterApplyDamage = (movementSyncId, id, damage) => {
     return console.log("해당 몬스터는 존재 하지않습니다.");
   }
 }
+
+// [유저 피격]
+export const userApplyDamage = (movementSyncId, userId, monsterId) =>{
+  if (!findMovementSync(movementSyncId)) {
+    console.log(`movementSync 가 존재 하지 않습니다 (id : ${movementSyncId})`);
+    return false;
+  }
+
+  console.log("[유저가 넉백하는 시점]")
+
+  // 유저, 몬스터 정보를 불러온다.
+  const monster = findMonster(movementSyncId, monsterId);
+  const user = findUser(movementSyncId, userId);
+
+  // 유저 넉백은 이동만.
+  user.updateDamageCount(1, 20, 40, 0.2, monster.getCurrentTransform());
+
+} 

--- a/src/movementSync/pathfinding/AStar.js
+++ b/src/movementSync/pathfinding/AStar.js
@@ -160,10 +160,10 @@ export class AStar {
             visited.add(`${nx},${ny}`); // 방문 체크는 여기서 추가
 
             if (this.isValid([nx, ny])) {
-              console.log('유효한 위치 저장: ', nx, ny);
+              // console.log('유효한 위치 저장: ', nx, ny);
               validPoints.push([nx, ny]); // 유효한 위치 저장
             } else {
-              console.log('유효한 위치 저장 못함: ', nx, ny);
+              // console.log('유효한 위치 저장 못함: ', nx, ny);
             }
           }
         }
@@ -178,7 +178,7 @@ export class AStar {
     // 유효한 위치 중 랜덤으로 하나 선택
     if (validPoints.length > 0) {
       let randomIndex = Math.floor(Math.random() * validPoints.length);
-      console.log('랜덤으로 선택된 인덱스:', randomIndex, '좌표:', validPoints[randomIndex]);
+      // console.log('랜덤으로 선택된 인덱스:', randomIndex, '좌표:', validPoints[randomIndex]);
       return validPoints[randomIndex];
     }
 

--- a/src/movementSync/pathfinding/testASter.js
+++ b/src/movementSync/pathfinding/testASter.js
@@ -274,7 +274,7 @@ export default class TestASter {
       return [x - this.offsetX + offsetX, y, z - this.offsetZ + offsetZ];
     });
 
-    console.log("pathCoords :", pathCoords);
+    // console.log("pathCoords :", pathCoords);
 
     return { gridIndexPath: path, pathCoords: pathCoords }; // 계산된 3D 경로 반환
   }
@@ -440,7 +440,6 @@ export default class TestASter {
 
     if(!storedValue) return false;
 
-    console.log("장애물인가? :", storedValue)
 
     return storedValue.value === 1;
   }

--- a/src/movementSync/pathfinding/testASter.js
+++ b/src/movementSync/pathfinding/testASter.js
@@ -13,10 +13,13 @@ export default class TestASter {
     const maxX = Math.max(...this.vertices.map((p) => p.x));
     const maxZ = Math.max(...this.vertices.map((p) => p.z));
 
-    // console.log('minX :', minX);
-    // console.log('minZ :', minZ);
-    // console.log('maxX :', maxX);
-    // console.log('maxZ :', maxZ);
+    console.log('minX :', minX);
+    console.log('minZ :', minZ);
+    console.log('maxX :', maxX);
+    console.log('maxZ :', maxZ);
+
+    // 안전구역 설정 
+    this.safeZone = 10;
 
     // 그리드 크기 설정
     this.gridWidth = Math.round(maxX + Math.abs(minX));
@@ -25,6 +28,12 @@ export default class TestASter {
     // 음수 좌표를 방지하기 위한 오프셋
     this.offsetX = minX < 0 ? Math.abs(minX) : minX;
     this.offsetZ = minZ < 0 ? Math.abs(minZ) : minZ;
+
+    // 세이프존 설정.
+    this.gridWidth += this.safeZone * 2;
+    this.gridHeight += this.safeZone * 2;
+    this.offsetX += this.safeZone;
+    this.offsetZ += this.safeZone;
 
     // A* 알고리즘을 위한 그리드 설정
     this.grid = new Grid({
@@ -38,14 +47,14 @@ export default class TestASter {
     // 장애물 저장 객체
     this.entityObstacles = {};
 
-    // console.log('gridWidth :', this.gridWidth);
-    // console.log('gridHeight :', this.gridHeight);
-    // console.log('offsetX :', this.offsetX);
-    // console.log('offsetZ :', this.offsetZ);
+    console.log('gridWidth :', this.gridWidth);
+    console.log('gridHeight :', this.gridHeight);
+    console.log('offsetX :', this.offsetX);
+    console.log('offsetZ :', this.offsetZ);
 
     // 정적 장애물 추가
 
-    //this.markStaticObstacles();
+    this.markStaticObstacles();
 
     //this.testPathfinding();
   }
@@ -265,6 +274,8 @@ export default class TestASter {
       return [x - this.offsetX + offsetX, y, z - this.offsetZ + offsetZ];
     });
 
+    console.log("pathCoords :", pathCoords);
+
     return { gridIndexPath: path, pathCoords: pathCoords }; // 계산된 3D 경로 반환
   }
 
@@ -426,6 +437,11 @@ export default class TestASter {
 
     const storedValue = this.grid.get([obstaclePos.index % this.gridWidth, Math.floor(obstaclePos.index / this.gridWidth)]);
     //console.log('경로에 장애물 : ', storedValue);
+
+    if(!storedValue) return false;
+
+    console.log("장애물인가? :", storedValue)
+
     return storedValue.value === 1;
   }
 

--- a/src/movementSync/utils/movementUtils.js
+++ b/src/movementSync/utils/movementUtils.js
@@ -1,10 +1,10 @@
 // 두 지점 사이의 거리 계산 함수
 // 주어진 이전 위치(previousTransform)와 현재 위치(currentTransform) 간의 3D 거리 차이를 계산합니다.
 const calculateDistance = (previousTransform, currentTransform) => {
-  if(previousTransform === currentTransform){
+  if (previousTransform === currentTransform) {
     return 0;
   }
-  
+
   // 3D 거리 계산 (피타고라스의 정리 사용)
   // (x1 - x2)^2 + (y1 - y2)^2 + (z1 - z2)^2 의 제곱근을 구합니다.
   const distance = Math.sqrt(
@@ -55,23 +55,23 @@ const calculateRotation = (previousTransform, currentTransform) => {
   // yaw 계산: 수평 회전 각도, xz평면에서의 회전 각도를 구함
   // Math.atan2(deltaX, deltaZ)는 xz평면에서의 각도를 계산하며, 이를 도(degree) 단위로 변환
   const yaw = Math.atan2(deltaX, deltaZ) * (180 / Math.PI);
-
+  const yaw2 = (Math.atan2(deltaX, deltaZ) * (180 / Math.PI) + 360) % 360;
   // pitch 계산: 수직 회전 각도, y축(높이)과 xz평면의 거리 차이를 기준으로 회전 각도를 구함
   const distanceXZ = Math.sqrt(deltaX * deltaX + deltaZ * deltaZ);
   const pitch = Math.atan2(deltaY, distanceXZ) * (180 / Math.PI);
 
   // 계산된 yaw와 pitch 반환
-  return { yaw, pitch };
+  return { yaw, yaw2, pitch };
 };
 
 // 현재 위치가 목표 지점을 지나쳤는지 여부를 확인하는 함수입니다.
 const hasPassedTarget = (currentTransform, targetTransform, lastTransform) => {
-  // 목표 지점과 현재 위치 간의 차이 계산 
+  // 목표 지점과 현재 위치 간의 차이 계산
   const deltaX = targetTransform.posX - currentTransform.posX;
   const deltaY = targetTransform.posY - currentTransform.posY;
   const deltaZ = targetTransform.posZ - currentTransform.posZ;
 
-  // 목표와 현재 위치 사이의 거리 계산 
+  // 목표와 현재 위치 사이의 거리 계산
   const distanceToTarget = Math.sqrt(deltaX * deltaX + deltaY * deltaY + deltaZ * deltaZ);
 
   // 목표 지점에 가까워졌을 때 지나친 것으로 판단 (0.1 미만으로 가까워졌다면)
@@ -79,7 +79,7 @@ const hasPassedTarget = (currentTransform, targetTransform, lastTransform) => {
     return true;
   }
 
-  // 마지막 위치와 목표 지점 간의 차이 계산 
+  // 마지막 위치와 목표 지점 간의 차이 계산
   const lastDeltaX = targetTransform.posX - lastTransform.posX;
   const lastDeltaY = targetTransform.posY - lastTransform.posY;
   const lastDeltaZ = targetTransform.posZ - lastTransform.posZ;
@@ -92,11 +92,77 @@ const hasPassedTarget = (currentTransform, targetTransform, lastTransform) => {
   return dotProduct < 0;
 };
 
+// [ OBB 충돌]
+const isInRotatedRange = (range, width, sourceTransform, targetTransform, rot = null) => {
+  let sourceRot = rot
+  if(rot === null) {
+    sourceRot = targetTransform.rot
+  }
+  
+  // 공격 범위의 네 꼭지점 계산
+  const { topLeft, topRight, bottomLeft, bottomRight } = calculateRotatedBox(range, width, sourceTransform, sourceRot);
+
+  // 대상이 공격 범위 내에 있는지 체크 (최소/최대 좌표를 이용한 충돌 감지)
+  const isTargetInRange =
+    targetTransform.posX >= Math.min(topLeft.x, topRight.x, bottomLeft.x, bottomRight.x) &&
+    targetTransform.posX <= Math.max(topLeft.x, topRight.x, bottomLeft.x, bottomRight.x) &&
+    targetTransform.posZ >= Math.min(topLeft.z, topRight.z, bottomLeft.z, bottomRight.z) &&
+    targetTransform.posZ <= Math.max(topLeft.z, topRight.z, bottomLeft.z, bottomRight.z);
+
+  return isTargetInRange;
+
+};
+
+const calculateRotatedBox = (range, width, sourceTransform, rot) => {
+  // 공격 범위 설정 (원본 객체의 회전 방향에 맞춰 회전된 박스형 범위)
+  const attackDistance = range; // 공격 거리 (원본 객체가 바라보는 방향으로 범위)
+  const attackWidth = width; // 공격 폭 (좌우 범위)
+
+  // 원본 객체의 forward 방향 벡터 (회전된 방향)
+  const forwardX = Math.cos(rot); // Y축 회전 기준
+  const forwardZ = Math.sin(rot);
+
+  // 원본 객체의 오른쪽 방향 벡터 (좌우로 벗어난 방향)
+  const rightX = -forwardZ;
+  const rightZ = forwardX;
+
+  // 원본 객체의 현재 위치
+  const sourceX = sourceTransform.posX;
+  const sourceZ = sourceTransform.posZ;
+
+  // 공격 범위의 중심을 계산
+  const centerX = sourceX + forwardX * (attackDistance / 2);
+  const centerZ = sourceZ + forwardZ * (attackDistance / 2);
+
+  // 공격 범위의 네 꼭지점을 계산
+  const topLeftX = centerX - (attackWidth / 2) * rightX;
+  const topLeftZ = centerZ - (attackWidth / 2) * rightZ;
+  const topRightX = centerX + (attackWidth / 2) * rightX;
+  const topRightZ = centerZ + (attackWidth / 2) * rightZ;
+
+  const bottomLeftX = centerX - (attackWidth / 2) * rightX - forwardX * attackDistance;
+  const bottomLeftZ = centerZ - (attackWidth / 2) * rightZ - forwardZ * attackDistance;
+  const bottomRightX = centerX + (attackWidth / 2) * rightX - forwardX * attackDistance;
+  const bottomRightZ = centerZ + (attackWidth / 2) * rightZ - forwardZ * attackDistance;
+
+  // 반환값을 꼭지점별로 묶어서 리턴
+  return {
+    topLeft: { x: topLeftX, z: topLeftZ },
+    topRight: { x: topRightX, z: topRightZ },
+    bottomLeft: { x: bottomLeftX, z: bottomLeftZ },
+    bottomRight: { x: bottomRightX, z: bottomRightZ }
+  };
+};
+
+
+
 const movementUtils = {
   Distance: calculateDistance,
   DirectionAndVelocity: calculateDirectionAndVelocity,
   Rotation: calculateRotation,
   hasPassedTarget: hasPassedTarget,
+  obbCollision:isInRotatedRange,
+  obbBox: calculateRotatedBox,
 };
 
 export default movementUtils;


### PR DESCRIPTION
1.  그리드에 세이프존 추가 (기존 그리드에 + 10 가로세로  추가 )
2.  엔티티 넉백 구현
3.  넉백시 이동할 곳을 미리 검증하여  장애물이라면 넉백 종료.
4.  몬스터 공격시 검증 aabb -> obb 변경
5.  유저 넉백은 몬스터 공격하는 시점으로 테스트로 달아놓음 (넉백 수정완료 후  삭제 예정)
6.  몬스터 행동 수정 
- 1. idle 상태 일 경우  자신이 바라보는 방향에  사각형을 만들어 충돌시 공격. 
- 2. idle 상태 일 경우 일정 거리를 멀어지면 탐색 시작. 
- 3. CHASE 상태 일 경우  자신이 바라보는 방향에 사각형을 만들어 충돌시 공격 행동으로 넘어감. 
- 4. ATTACK상태 일 경우 한번 공격하고 일정시간 후에 idle 로 번경 (현재 테스트를 위해  리스폰 지역으로 가는 행동을 넣음.)